### PR TITLE
Support/related artists model deserialization

### DIFF
--- a/src/SpotifyApi.NetCore.Tests/ArtistsApiTests.cs
+++ b/src/SpotifyApi.NetCore.Tests/ArtistsApiTests.cs
@@ -100,5 +100,22 @@ namespace SpotifyApi.NetCore.Tests
             var result = await artists.GetArtistsTopTracks(artistId, market);
         }
 
+        [TestMethod]
+        [TestCategory("Integration")]
+        public async Task GetRelatedArtists_When_Given_Valid_ArtistId_Returns_Artists()
+        {
+            // arrange
+            const string artistId = "6lcwlkAjBPSKnFBZjjZFJs";
+
+            var http = new HttpClient();
+            var accounts = new AccountsService(http, TestsHelper.GetLocalConfig());
+            var artists = new ArtistsApi(http, accounts);
+
+            // act
+            var result = await artists.GetRelatedArtists(artistId);
+
+            // assert
+            Assert.AreNotSame(result.Length, 0);
+        }
     }
 }

--- a/src/SpotifyApi.NetCore.Tests/TestsHelper.cs
+++ b/src/SpotifyApi.NetCore.Tests/TestsHelper.cs
@@ -9,6 +9,7 @@ namespace SpotifyApi.NetCore.Tests
         {
             return new ConfigurationBuilder()
                 // Using "..", "..", ".." vs. "..\\..\\.." for system-agnostic path resolution
+                // Reference: https://stackoverflow.com/questions/14899422/how-to-navigate-a-few-folders-up#comment97806320_30902714
                 .SetBasePath(Path.Combine(Directory.GetCurrentDirectory(), "..", "..", ".."))
                 .AddJsonFile("appsettings.local.json", false)
                 .Build();

--- a/src/SpotifyApi.NetCore.Tests/TestsHelper.cs
+++ b/src/SpotifyApi.NetCore.Tests/TestsHelper.cs
@@ -8,7 +8,8 @@ namespace SpotifyApi.NetCore.Tests
         public static IConfiguration GetLocalConfig()
         {
             return new ConfigurationBuilder()
-                .SetBasePath(Path.Combine(Directory.GetCurrentDirectory(), "..\\..\\.."))
+                // Using "..", "..", ".." vs. "..\\..\\.." for system-agnostic path resolution
+                .SetBasePath(Path.Combine(Directory.GetCurrentDirectory(), "..", "..", ".."))
                 .AddJsonFile("appsettings.local.json", false)
                 .Build();
         }

--- a/src/SpotifyApi.NetCore/ArtistsApi.cs
+++ b/src/SpotifyApi.NetCore/ArtistsApi.cs
@@ -93,7 +93,7 @@ namespace SpotifyApi.NetCore
         /// <typeparam name="T">Optionally provide your own type to deserialise Spotify's response to.</typeparam>
         /// <returns>Task of T. The Spotify response is deserialised as T.</returns>
         public async Task<T> GetRelatedArtists<T>(string artistId, string accessToken = null)
-            => await GetModel<T>($"{BaseUrl}/artists/{SpotifyUriHelper.ArtistId(artistId)}/related-artists", accessToken);
+            => await GetModelFromProperty<T>($"{BaseUrl}/artists/{SpotifyUriHelper.ArtistId(artistId)}/related-artists", "artists", accessToken);
 
         #endregion
 


### PR DESCRIPTION
Fixes #18 

Added an integration test for this method as well, as it was lacking one. Also updated the `TestsHelper` class to allow for the testing config to be found on a non-Windows platform.