### PR TITLE
Completed PlaylistsApi.RemoveItems.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,4 +168,3 @@ Huge thanks to **@aevansme**, **@brandongregoryscott** and **@akshays2112** for 
 Contributions welcomed. Read [CONTRIB.md](./CONTRIB.md)
 
 [SpotifyApi.NetCore.Samples]:https://github.com/Ringobot/SpotifyApi.NetCore.Samples
-

--- a/README.md
+++ b/README.md
@@ -169,16 +169,3 @@ Contributions welcomed. Read [CONTRIB.md](./CONTRIB.md)
 
 [SpotifyApi.NetCore.Samples]:https://github.com/Ringobot/SpotifyApi.NetCore.Samples
 
-
-
-
-
-
-
-To be all deleted by Daniel Larson only contributed by "um" scary me everyone will not follow etc.:::::
-Hey Daniel Larson you are a greatest guy in your NZ place who got collaped by some assholes like this who
-talk about why I am given the exception here in Mumbai/Dumbai/"um"WhatsItsName and they are all talking
-about my skin color here in Moms apartment still. Lol. Take care of yourself buddy now you know the game
-just stay alive long as you can as the non-whites at Otters club say while I breeze through them. Play
-your role to perfection as you always do. Hey you had to explain to me how this thing github works
-THX BRO!!!

--- a/README.md
+++ b/README.md
@@ -168,3 +168,17 @@ Huge thanks to **@aevansme**, **@brandongregoryscott** and **@akshays2112** for 
 Contributions welcomed. Read [CONTRIB.md](./CONTRIB.md)
 
 [SpotifyApi.NetCore.Samples]:https://github.com/Ringobot/SpotifyApi.NetCore.Samples
+
+
+
+
+
+
+
+To be all deleted by Daniel Larson only contributed by "um" scary me everyone will not follow etc.:::::
+Hey Daniel Larson you are a greatest guy in your NZ place who got collaped by some assholes like this who
+talk about why I am given the exception here in Mumbai/Dumbai/"um"WhatsItsName and they are all talking
+about my skin color here in Moms apartment still. Lol. Take care of yourself buddy now you know the game
+just stay alive long as you can as the non-whites at Otters club say while I breeze through them. Play
+your role to perfection as you always do. Hey you had to explain to me how this thing github works
+THX BRO!!!

--- a/src/SpotifyApi.NetCore.Tests/PlaylistsTests.cs
+++ b/src/SpotifyApi.NetCore.Tests/PlaylistsTests.cs
@@ -252,5 +252,44 @@ namespace SpotifyApi.NetCore.Tests
             var playlistCoverImages = await api.GetPlaylistCoverImage<Image[]>("3cEYpjA9oz9GiPac4AsH4n", accessToken);
             Assert.IsTrue(playlistCoverImages.Length > 0, "No playlist images were found.");
         }
+
+        [TestMethod]
+        [TestCategory("Integration")]
+        public async Task RemoveItems_PlaylistId_SpotifyUris_SnapshotIdIsNotNull()
+        {
+            // act
+            Assert.IsNotNull(await api.RemoveItems("46sqDMykUCnssu2F3zWXEF", new string[] { "spotify:track:5ArQzSBevAdXTxRY6Ulhbq" },
+                    accessToken: await TestsHelper.GetUserAccessToken()));
+        }
+
+        [TestMethod]
+        [TestCategory("Integration")]
+        public async Task RemoveItems_PlaylistId_SpotifyUris_SnapshotId_SnapshotIdIsNotNull()
+        {
+            // act
+            Assert.IsNotNull(await api.RemoveItems("46sqDMykUCnssu2F3zWXEF", new string[] { "spotify:track:5ArQzSBevAdXTxRY6Ulhbq" },
+                    "MTQsMWNlNjE5NWJkYWFjOTNmNDM1M2NjZDM4NGNjMWViMTZlNzk0ZWEyYw==", accessToken: await TestsHelper.GetUserAccessToken()));
+        }
+
+        [TestMethod]
+        [TestCategory("Integration")]
+        public async Task RemoveItems_PlaylistId_SpotifyUriLocations_SnapshotIdIsNotNull()
+        {
+            // act
+            Assert.IsNotNull(await api.RemoveItems("46sqDMykUCnssu2F3zWXEF", 
+                new (string uri, int[] positions)[] { ("spotify:track:1Eolhana7nKHYpcYpdVcT5", new int[] { 0 }) },
+                    accessToken: await TestsHelper.GetUserAccessToken()));
+        }
+
+        [TestMethod]
+        [TestCategory("Integration")]
+        public async Task RemoveItems_PlaylistId_SpotifyUriLocations_SnapshotId_SnapshotIdIsNotNull()
+        {
+            // act
+            Assert.IsNotNull(await api.RemoveItems("46sqDMykUCnssu2F3zWXEF",
+                new (string uri, int[] positions)[] { ("spotify:track:7iL6o9tox1zgHpKUfh9vuC", new int[] { 0 }) },
+                    "MTQsMWNlNjE5NWJkYWFjOTNmNDM1M2NjZDM4NGNjMWViMTZlNzk0ZWEyYw==", accessToken: await TestsHelper.GetUserAccessToken()));
+        }
+
     }
 }

--- a/src/SpotifyApi.NetCore.Tests/TracksApiTests.cs
+++ b/src/SpotifyApi.NetCore.Tests/TracksApiTests.cs
@@ -52,8 +52,8 @@ namespace SpotifyApi.NetCore.Tests
         public async Task GetTrack_TrackIdMarket_AvailableMarketsIsNull()
         {
             // arrange
-            const string trackId = "5lA3pwMkBdd24StM90QrNR";
-            const string market = SpotifyCountryCodes.New_Zealand;
+            const string trackId = "11dFghVXANMlKmJXsNCbd8";
+            const string market = SpotifyCountryCodes.Spain;
 
             var http = new HttpClient();
             var accounts = new AccountsService(http, TestsHelper.GetLocalConfig());
@@ -64,7 +64,7 @@ namespace SpotifyApi.NetCore.Tests
             var response = await api.GetTrack(trackId, market);
 
             // assert
-            Assert.IsNull(response.AvailableMarkets);
+            Assert.IsNull(response?.AvailableMarkets?.Length == 0 ? null : "Array not empty.");
         }
 
         [TestCategory("Integration")]

--- a/src/SpotifyApi.NetCore/Models/PlaylistRemoveItemsPayloadData.cs
+++ b/src/SpotifyApi.NetCore/Models/PlaylistRemoveItemsPayloadData.cs
@@ -1,0 +1,56 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace SpotifyApi.NetCore.Models
+{
+    public partial class PlaylistRemoveItemsPayloadDataUriItems
+    {
+
+        public PlaylistRemoveItemsPayloadDataUriItems(string[] uris, string snapshotId = null)
+        {
+            Uris = new PlaylistRemoveItemsPayloadDataUriItem[uris.Length];
+            for (int i = 0; i < Uris.Length; i++)
+            {
+                Uris[i] = new PlaylistRemoveItemsPayloadDataUriItem(uris[i]);
+            }
+            SnapshotId = snapshotId;
+        }
+
+        public PlaylistRemoveItemsPayloadDataUriItems((string uri, int[] positions)[] uriPositions, string snapshotId = null)
+        {
+            Uris = new PlaylistRemoveItemsPayloadDataUriItem[uriPositions.Length];
+            for (int i = 0; i < Uris.Length; i++)
+            {
+                Uris[i] = new PlaylistRemoveItemsPayloadDataUriItem(uriPositions[i]);
+            }
+            SnapshotId = snapshotId;
+        }
+
+        [JsonProperty("tracks", NullValueHandling = NullValueHandling.Ignore)]
+        public PlaylistRemoveItemsPayloadDataUriItem[] Uris { get; set; }
+
+        [JsonProperty("snapshot_id", NullValueHandling = NullValueHandling.Ignore)]
+        public string SnapshotId { get; set; }
+
+    }
+
+    public partial class PlaylistRemoveItemsPayloadDataUriItem
+    {
+
+        public PlaylistRemoveItemsPayloadDataUriItem(string uri) => this.Uri = uri;
+
+        public PlaylistRemoveItemsPayloadDataUriItem((string uri, int[] positions) uriPositions)
+        {
+            Uri = uriPositions.uri;
+            Positions = uriPositions.positions;
+        }
+
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+
+        [JsonProperty("positions", NullValueHandling = NullValueHandling.Ignore)]
+        public int[] Positions { get; set; }
+
+    }
+
+}

--- a/src/SpotifyApi.NetCore/PlaylistsApi.cs
+++ b/src/SpotifyApi.NetCore/PlaylistsApi.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using System.Text;
+using SpotifyApi.NetCore.Models;
 
 namespace SpotifyApi.NetCore
 {
@@ -464,11 +465,21 @@ namespace SpotifyApi.NetCore
         /// <remarks>
         /// https://developer.spotify.com/documentation/web-api/reference/playlists/remove-tracks-playlist/
         /// </remarks>
-        public Task<ModifyPlaylistResponse> RemoveItems(
+        public async Task<ModifyPlaylistResponse> RemoveItems(
             string playlistId,
             string[] spotifyUris,
             string snapshotId = null,
-            string accessToken = null) => throw new NotImplementedException();
+            string accessToken = null)
+        {
+            if (string.IsNullOrWhiteSpace(playlistId)) throw new
+                ArgumentException("A valid Spotify playlist id must be specified.");
+
+            if (spotifyUris?.Length < 1 || spotifyUris?.Length > 100) throw new
+                     ArgumentException("A minimum of 1 and a maximum of 100 Spotify uri must be specified.");
+
+            var builder = new UriBuilder($"{BaseUrl}/playlists/{playlistId}/tracks");
+            return (await Delete<ModifyPlaylistResponse>(builder.Uri, new PlaylistRemoveItemsPayloadDataUriItems(spotifyUris, snapshotId), accessToken)).Data;
+        }
 
         /// <summary>
         /// Remove one or more items from a user’s playlist.
@@ -485,11 +496,21 @@ namespace SpotifyApi.NetCore
         /// <remarks>
         /// https://developer.spotify.com/documentation/web-api/reference/playlists/remove-tracks-playlist/
         /// </remarks>
-        public Task<ModifyPlaylistResponse> RemoveItems(
+        public async Task<ModifyPlaylistResponse> RemoveItems(
             string playlistId,
             (string uri, int[] positions)[] spotifyUriPositions,
             string snapshotId = null,
-            string accessToken = null) => throw new NotImplementedException();
+            string accessToken = null)
+        {
+            if (string.IsNullOrWhiteSpace(playlistId)) throw new
+                ArgumentException("A valid Spotify playlist id must be specified.");
+
+            if (spotifyUriPositions?.Length < 1 || spotifyUriPositions?.Length > 100) throw new
+                     ArgumentException("A minimum of 1 and a maximum of 100 Spotify uri and positions must be specified.");
+
+            var builder = new UriBuilder($"{BaseUrl}/playlists/{playlistId}/tracks");
+            return (await Delete<ModifyPlaylistResponse>(builder.Uri, new PlaylistRemoveItemsPayloadDataUriItems(spotifyUriPositions, snapshotId), accessToken)).Data;
+        }
 
         #endregion
 

--- a/src/SpotifyApi.NetCore/SpotifyApi.NetCore.csproj
+++ b/src/SpotifyApi.NetCore/SpotifyApi.NetCore.csproj
@@ -26,6 +26,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Due to HttpClient.Delete not having support for HttpContent payloads for which I have raised an Issue in dotnetcore and they are going to update this possibly in later versions. They have recommended using the workaround of using SendAsync. So added a new Delete overload using SendAsync to SpotifyWebApi.cs.

In this, I also have my correction for the Test case where IsNull fails for me when it is an initialized array with no elements.
